### PR TITLE
Add magic to the arguments mapping

### DIFF
--- a/Classes/CDSRC/Libraries/Translatable/Aspect/TranslatableAspect.php
+++ b/Classes/CDSRC/Libraries/Translatable/Aspect/TranslatableAspect.php
@@ -87,6 +87,8 @@ class TranslatableAspect
             if (is_array($rawValue) && !isset($rawValue['translations'])) {
                 $translationClassName = $this->getTranslationTable($argument->getDataType());
                 if ($translationClassName instanceof GenericTranslation) {
+                    // TODO: Implement generic version
+                    throw \Exception('NOT IMPLEMENTED');
                 } else {
                     $finalValue = array();
                     $translationProperties = $this->getTranslationProperties($translationClassName);

--- a/Classes/CDSRC/Libraries/Translatable/Aspect/TranslatableAspect.php
+++ b/Classes/CDSRC/Libraries/Translatable/Aspect/TranslatableAspect.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace CDSRC\Libraries\Translatable\Aspect;
+
+
+/* **********************************************************************
+ *
+ *  Copyright notice
+ *
+ *  (c) 2015 Matthias Toscanelli <m.toscanelli@code-source.ch>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ * ******************************************************************** */
+
+use CDSRC\Libraries\Translatable\Domain\Model\AbstractTranslatable;
+use CDSRC\Libraries\Translatable\Domain\Model\GenericTranslation;
+use CDSRC\Libraries\Translatable\Domain\Model\TranslatableInterface;
+use Doctrine\ORM\Query;
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Aop\JoinPointInterface;
+use TYPO3\Flow\Mvc\Controller\Argument;
+use TYPO3\Flow\Mvc\Controller\MvcPropertyMappingConfiguration;
+use TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter;
+use TYPO3\Flow\Reflection\ReflectionService;
+
+/**
+ * An aspect which centralizes the logging of security relevant actions.
+ *
+ * @Flow\Scope("singleton")
+ * @Flow\Aspect
+ */
+class TranslatableAspect
+{
+
+    /**
+     * @var ReflectionService
+     * @Flow\Inject
+     */
+    protected $reflectionService;
+
+    /**
+     * @var \Doctrine\Common\Persistence\ObjectManager
+     * @Flow\Inject
+     */
+    protected $entityManager;
+
+    /**
+     * @var array
+     */
+    protected $translationClassNames = array();
+
+    /**
+     * @var array
+     */
+    protected $translationProperties = array();
+
+    /**
+     * @var array
+     */
+    protected $translationIdentifierPropertyName = array();
+
+    /**
+     *
+     * @Flow\Before("method(TYPO3\Flow\Mvc\Controller\Argument->setValue())")
+     * @param JoinPointInterface $joinPoint The current joinpoint
+     *
+     * @return void
+     */
+    public function fixTranslatableArguments(JoinPointInterface $joinPoint)
+    {
+        /** @var Argument $argument */
+        $argument = $joinPoint->getProxy();
+        if ($this->reflectionService->isClassImplementationOf($argument->getDataType(), TranslatableInterface::class)) {
+            $rawValue = $joinPoint->getMethodArgument('rawValue');
+            if (is_array($rawValue) && !isset($rawValue['translations'])) {
+                $translationClassName = $this->getTranslationTable($argument->getDataType());
+                if ($translationClassName instanceof GenericTranslation) {
+                } else {
+                    $finalValue = array();
+                    $translationProperties = $this->getTranslationProperties($translationClassName);
+                    $translations = array();
+                    foreach ($rawValue as $property => $value) {
+                        if (is_array($value) && in_array($property, $translationProperties)) {
+                            $defaultLanguageValue = null;
+                            foreach ($value as $language => $languageValue) {
+                                // "default" language key is used to set default language in main class
+                                if ($language === 'default') {
+                                    $defaultLanguageValue = $languageValue;
+                                } else {
+                                    $translations[$language][$property] = $languageValue;
+                                }
+                            }
+                            if ($defaultLanguageValue !== null) {
+                                $rawValue[$property] = $defaultLanguageValue;
+                            } else {
+                                unset($rawValue[$property]);
+                            }
+                        } else {
+                            $finalValue[$property] = $value;
+                        }
+                    }
+                    if (!empty($translations)) {
+                        $identifierPropertyName = $this->getTranslationIdentifierPropertyName($translationClassName);
+                        // Retrieve UUID of existing translation if mapping an existing object
+                        if (isset($rawValue['__identity']) && $identifierPropertyName) {
+                            $translationsData = $this->findTranslationsIdentifiersAndLocale($translationClassName, $rawValue['__identity'], $identifierPropertyName);
+                            if(is_array($translationsData)) {
+                                foreach ($translationsData as $data) {
+                                    if(isset($translations[$data['i18nLocale']])){
+                                        $translations[$data['i18nLocale']]['__identity'] = $data['__identity'];
+                                    }
+                                }
+                            }
+                        }
+                        $index = 0;
+                        /** @var MvcPropertyMappingConfiguration $propertyMappingConfiguration */
+                        $propertyMappingConfiguration = $argument->getPropertyMappingConfiguration();
+                        $propertyMappingConfiguration->allowProperties('translations');
+                        $propertyMappingConfiguration->setTargetTypeForSubProperty('translations', 'Doctrine\Common\Collections\Collection<\\'.$translationClassName.'>');
+                        foreach ($translations as $language => $translation) {
+                            $rawValue['translations'][$index] = $translation;
+                            $propertyPath = 'translations.'.$index;
+                            $propertyMappingConfiguration->setTargetTypeForSubProperty($propertyPath, $translationClassName);
+                            $translationMappingConfiguration = $propertyMappingConfiguration->forProperty($propertyPath);
+                            if(isset($translation['__identity'])){
+                                $propertyMappingConfiguration->allowModificationForSubProperty($propertyPath);
+                            }else{
+                                $propertyMappingConfiguration->allowCreationForSubProperty($propertyPath);
+                                $translationMappingConfiguration->allowProperties('i18nLocale');
+                                $rawValue['translations'][$index]['i18nLocale'] = $language;
+                            }
+                            call_user_func_array(array($translationMappingConfiguration, 'allowProperties'), $translationProperties);
+                            $index++;
+                        }
+                        call_user_func_array(array($propertyMappingConfiguration->forProperty('translations'), 'allowProperties'), array_keys($rawValue['translations']));
+                    }
+                }
+            }
+            $joinPoint->setMethodArgument('rawValue', $rawValue);
+        }
+    }
+
+    /**
+     * @param string $className
+     */
+    protected function getTranslationTable($className)
+    {
+        if (!isset($this->translationClassNames[$className])) {
+            $specificTranslationClassName = $className . 'Translation';
+            if (class_exists($specificTranslationClassName)) {
+                $this->translationClassNames[$className] = $specificTranslationClassName;
+            } else {
+                $this->translationClassNames[$className] = 'CDSRC\Libraries\Translatable\Domain\Model\GenericTranslation';
+            }
+        }
+
+        return $this->translationClassNames[$className];
+    }
+
+    /**
+     * Get available properties for translation class
+     *
+     * @param $translationClassName
+     *
+     * @return array
+     */
+    protected function getTranslationProperties($translationClassName)
+    {
+        if (!isset($this->translationProperties[$translationClassName])) {
+            $properties = $this->reflectionService->getClassPropertyNames($translationClassName);
+            foreach ($properties as $key => $value) {
+                $annotations = $this->reflectionService->getPropertyAnnotations($translationClassName, $value);
+                if (isset($annotations['CDSRC\Libraries\Translatable\Annotations\Locked']) ||
+                    isset($annotations['Doctrine\ORM\Mapping\Id']) ||
+                    isset($annotations['TYPO3\Flow\Annotations\Transient']) ||
+                    isset($annotations['TYPO3\Flow\Annotations\Inject'])
+                ) {
+                    unset($properties[$key]);
+                }
+            }
+            $this->translationProperties[$translationClassName] = array_values($properties);
+        }
+
+        return $this->translationProperties[$translationClassName];
+    }
+
+    /**
+     * Get identifier property name for translation class
+     *
+     * @param $translationClassName
+     *
+     * @return string
+     */
+    protected function getTranslationIdentifierPropertyName($translationClassName)
+    {
+        if (!isset($this->translationIdentifierPropertyName[$translationClassName])) {
+            $propertyNames = $this->reflectionService->getPropertyNamesByAnnotation($translationClassName, 'Doctrine\ORM\Mapping\Id');
+            $this->translationIdentifierPropertyName[$translationClassName] = isset($propertyNames[0]) ? $propertyNames[0]: null;
+        }
+
+        return $this->translationIdentifierPropertyName[$translationClassName];
+    }
+
+    /**
+     * @param $className
+     * @param $parentIdentifier
+     * @param string $identifierPropertyName
+     *
+     * @return mixed
+     */
+    public function findTranslationsIdentifiersAndLocale($className, $parentIdentifier, $identifierPropertyName = 'Persistence_Object_Identifier'){
+        /** @var QueryBuilder $queryBuilder */
+        $queryBuilder = $this->entityManager->createQueryBuilder();
+        return $queryBuilder
+            ->select('t.'.$identifierPropertyName .' AS __identity', 't.i18nLocale')
+            ->from($className, 't')
+            ->andWhere('t.i18nParent = :identifier')
+            ->setParameter('identifier', $parentIdentifier)
+            ->getQuery()->execute(null, Query::HYDRATE_ARRAY);
+    }
+}

--- a/Classes/CDSRC/Libraries/Translatable/Domain/Model/AbstractTranslatable.php
+++ b/Classes/CDSRC/Libraries/Translatable/Domain/Model/AbstractTranslatable.php
@@ -137,7 +137,7 @@ abstract class AbstractTranslatable implements TranslatableInterface
      */
     public function hasTranslationForLocale(Locale $locale)
     {
-        return $this->getTranslationObjectForLocale($locale) !== false;
+        return $this->getTranslationObjectForLocale($locale) !== null;
     }
 
     /**
@@ -164,12 +164,12 @@ abstract class AbstractTranslatable implements TranslatableInterface
      *
      * @param Locale $locale
      * @param bool $forceCreation
-     * @return bool|TranslationInterface
+     * @return null|TranslationInterface
      */
     public function getTranslationByLocale(Locale $locale, $forceCreation = false)
     {
         $translation = $this->getTranslationObjectForLocale($locale);
-        if ($translation) {
+        if ($translation !== null) {
             return $translation;
         }
 
@@ -206,7 +206,7 @@ abstract class AbstractTranslatable implements TranslatableInterface
     public function removeTranslationByLocale(Locale $locale)
     {
         $translation = $this->getTranslationObjectForLocale($locale);
-        if ($translation) {
+        if ($translation !== null) {
             $this->translations->removeElement($translation);
         }
 
@@ -290,7 +290,7 @@ abstract class AbstractTranslatable implements TranslatableInterface
     {
         $this->curTranslation = $this->getTranslationObjectForLocale($locale);
 
-        if(false === $this->curTranslation && $forceCreation){
+        if($this->curTranslation === null && $forceCreation){
             $this->curTranslation = $this->createTranslation($locale);
         }
 
@@ -340,7 +340,7 @@ abstract class AbstractTranslatable implements TranslatableInterface
             $previousParam = prev($arguments);
             if (is_bool($lastParam) && $previousParam instanceof Locale) {
                 $translation = $this->getTranslationObjectForLocale($previousParam);
-                if (!$translation && $lastParam) {
+                if ($translation === null && $lastParam) {
                     $translation = $this->createTranslation($previousParam);
                 }
                 // Remove the two last parameters as we just "consumed" them
@@ -349,7 +349,7 @@ abstract class AbstractTranslatable implements TranslatableInterface
             }
         }
 
-        if (!$translation) {
+        if ($translation === null) {
             return null;
         }
 
@@ -360,7 +360,7 @@ abstract class AbstractTranslatable implements TranslatableInterface
      * Go through all the translation objects and return the one that matches the given locale or false if none were found.
      *
      * @param Locale $locale
-     * @return bool|TranslationInterface
+     * @return null|TranslationInterface
      */
     protected function getTranslationObjectForLocale(Locale $locale)
     {
@@ -372,7 +372,7 @@ abstract class AbstractTranslatable implements TranslatableInterface
             }
         }
 
-        return false;
+        return null;
     }
 
     /**
@@ -384,7 +384,7 @@ abstract class AbstractTranslatable implements TranslatableInterface
     protected function createTranslation(Locale $locale)
     {
         $translation = $this->getTranslationObjectForLocale($locale);
-        if (!$translation) {
+        if ($translation === null) {
             $translationClassName = $this->getTranslationClassName();
             $translation = new $translationClassName($locale);
             $this->addTranslation($translation);

--- a/Classes/CDSRC/Libraries/Translatable/Domain/Model/AbstractTranslatable.php
+++ b/Classes/CDSRC/Libraries/Translatable/Domain/Model/AbstractTranslatable.php
@@ -55,16 +55,6 @@ abstract class AbstractTranslatable implements TranslatableInterface
     protected $fallbackOnTranslation = true;
 
     /**
-     * Store unannotated translatable fields
-     * Notice: if you override this field in child classes, this property has to be transient (otherwise an unneeded
-     * field will be created in the DB).
-     *
-     * @Flow\Transient
-     * @var array
-     */
-    protected $translatableFields = array();
-
-    /**
      * List of translations
      *
      * @var \Doctrine\Common\Collections\Collection<\CDSRC\Libraries\Translatable\Domain\Model\AbstractTranslation>
@@ -260,22 +250,13 @@ abstract class AbstractTranslatable implements TranslatableInterface
 
     /**
      * Return unannotated translatable fields
+     * NOTICE: This function should be override in sub classes if needed.
      *
      * @return array
      */
-    public function getTranslatableFields()
+    public static function getTranslatableFields()
     {
-        return $this->translatableFields;
-    }
-
-    /**
-     * Set the translatable fields.
-     *
-     * @param array $fields The name of the translatable fields
-     */
-    public function setTranslatableFields($fields)
-    {
-        $this->translatableFields = $fields;
+        return array();
     }
 
     /**

--- a/Classes/CDSRC/Libraries/Translatable/Domain/Validator/AbstractTranslationValidator.php
+++ b/Classes/CDSRC/Libraries/Translatable/Domain/Validator/AbstractTranslationValidator.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace CDSRC\Libraries\Translatable\Domain\Validator;
+
+
+/* **********************************************************************
+ *
+ *  Copyright notice
+ *
+ *  (c) 2015 Matthias Toscanelli <m.toscanelli@code-source.ch>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ * ******************************************************************** */
+
+use CDSRC\Libraries\Translatable\Domain\Model\AbstractTranslatable;
+use CDSRC\Libraries\Translatable\Domain\Model\AbstractTranslation;
+use TYPO3\Flow\Annotations as Flow;
+use TYPO3\Flow\Validation\Validator\AbstractValidator;
+
+class AbstractTranslationValidator extends AbstractValidator
+{
+
+    /**
+     * @var \TYPO3\Flow\Validation\ValidatorResolver
+     * @Flow\Inject
+     */
+    protected $validatorResolver;
+
+    /**
+     * Check if $value is valid. If it is not valid, needs to add an error
+     * to Result.
+     *
+     * @param mixed $value
+     *
+     * @return void
+     * @throws \TYPO3\Flow\Validation\Exception\InvalidValidationOptionsException if invalid validation options have been specified in the constructor
+     */
+    protected function isValid($value)
+    {
+        if (!$value instanceof AbstractTranslation) {
+            $this->addError('The given Object is not a translation.', 1448509134);
+            return;
+        }
+        $translationClassName = get_class($value);
+        $baseValidatorConjunction = $this->validatorResolver->getBaseValidatorConjunction($translationClassName);
+        $this->result = $baseValidatorConjunction->validate($value);
+    }
+}

--- a/Tests/Functional/Translatable/Fixture/Model/Category.php
+++ b/Tests/Functional/Translatable/Fixture/Model/Category.php
@@ -35,7 +35,6 @@ class Category extends AbstractTranslatable
     public function __construct()
     {
         parent::__construct();
-        $this->setTranslatableFields(array('title'));
     }
 
     /** @return string */
@@ -79,4 +78,14 @@ class Category extends AbstractTranslatable
         $this->isActive = $isActive;
         return $this;
     }
+
+	/**
+	 * Return unannotated translatable fields
+	 *
+	 * @return array
+	 */
+	public static function getTranslatableFields()
+	{
+		return array('title');
+	}
 }

--- a/Tests/Functional/Translatable/Fixture/Model/CategoryTranslation.php
+++ b/Tests/Functional/Translatable/Fixture/Model/CategoryTranslation.php
@@ -12,6 +12,8 @@ class CategoryTranslation extends AbstractTranslation
 {
     /**
      * @var string
+     * @Flow\Validate(type="NotEmpty")
+     * @Flow\Validate(type="StringLength", options={"maximum"=200})
      */
     protected $title;
 }

--- a/Tests/Functional/Translatable/TranslateMappingTest.php
+++ b/Tests/Functional/Translatable/TranslateMappingTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace CDSRC\Libraries\Tests\Functional\Translatable;
+
+/*******************************************************************************
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ******************************************************************************/
+
+use CDSRC\Libraries\Tests\Functional\Translatable\Fixture\Model\Category;
+use CDSRC\Libraries\Tests\Functional\Translatable\Fixture\Model\Entity;
+use CDSRC\Libraries\Tests\Functional\Translatable\Fixture\Model\Generic;
+use CDSRC\Libraries\Tests\Functional\Translatable\Fixture\Model\Specific;
+use CDSRC\Libraries\Tests\Functional\Translatable\Fixture\Repository\CategoryRepository;
+use CDSRC\Libraries\Tests\Functional\Translatable\Fixture\Repository\EntityRepository;
+use TYPO3\Flow\I18n\Locale;
+use TYPO3\Flow\Mvc\Controller\Argument;
+use TYPO3\Flow\Persistence\Doctrine\PersistenceManager;
+use TYPO3\Flow\Tests\FunctionalTestCase;
+
+/**
+ * Test case for translation
+ *
+ * @author Matthias Toscanelli <m.toscanelli@code-source.ch>
+ */
+class TranslateMappingTest extends FunctionalTestCase
+{
+
+    /**
+     * @var boolean
+     */
+    static protected $testablePersistenceEnabled = true;
+
+    /**
+     *
+     * @var \TYPO3\Flow\Property\PropertyMapper
+     */
+    protected $propertyMapper;
+
+    /** @var Locale */
+    protected $localeDe;
+
+    /** @var Locale */
+    protected $localeFr;
+
+    /** @var Locale */
+    protected $localeEn;
+
+    /** @var Locale */
+    protected $localeIt;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+        if (!$this->persistenceManager instanceof PersistenceManager) {
+            $this->markTestSkipped('Doctrine persistence is not enabled');
+        }
+        $this->propertyMapper = $this->objectManager->get('TYPO3\Flow\Property\PropertyMapper');
+
+        $this->localeDe = new Locale('de-CH');
+        $this->localeFr = new Locale('fr-CH');
+        $this->localeEn = new Locale('en-US');
+        $this->localeIt = new Locale('it-IT');
+    }
+
+    /**
+     * @test
+     */
+    public function testMappingMagic(){
+        $deTitle = 'Title DE';
+        $frTitle = 'Title FR';
+        $enTitle = 'Title EN';
+        $itTitle = 'Title IT';
+        $data = array(
+            (string)$this->localeDe => array(
+                $this->localeDe,
+                $deTitle
+            ),
+            (string)$this->localeFr => array(
+                $this->localeFr,
+                $frTitle
+            ),
+            (string)$this->localeEn => array(
+                $this->localeEn,
+                $enTitle
+            ),
+            (string)$this->localeIt => array(
+                $this->localeIt,
+                $itTitle
+            ),
+        );
+        $category = array(
+            'icon' => 'test',
+            'color' => '#ffffff',
+            'title' => array(
+                (string)$this->localeDe => $deTitle,
+                (string)$this->localeFr => $frTitle,
+                (string)$this->localeEn => $enTitle,
+                (string)$this->localeIt => $itTitle,
+            )
+        );
+        $argument = new Argument('category', \CDSRC\Libraries\Tests\Functional\Translatable\Fixture\Model\Category::class);
+        $argument->setRequired(true);
+
+        $propertyMappingConfiguration = $argument->getPropertyMappingConfiguration();
+        $propertyMappingConfiguration->allowAllProperties('icon', 'color');
+        $propertyMappingConfiguration->setTypeConverterOption('TYPO3\\Flow\\Property\\TypeConverter\\PersistentObjectConverter',  \TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_CREATION_ALLOWED, TRUE);
+
+        $argument->setValue($category);
+
+        /** @var Category $categoryObject */
+        $categoryObject = $argument->getValue();
+
+        foreach($data as $localeAndTitle){
+            $translation = $categoryObject->getTranslationByLocale($localeAndTitle[0], false);
+            $this->assertNotNull($translation);
+            if($translation){
+                $this->assertEquals($localeAndTitle[1], $translation->getTitle());
+            }
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function testMappingExistingTranslation(){
+        $category = new Category();
+        $category->setColor('#cccccc');
+        $category->setIcon('none');
+        $category->setCurrentLocale($this->localeEn, true)->setTitle('Title EN saved');
+        $category->setCurrentLocale($this->localeFr, true)->setTitle('Title FR saved');
+
+        $repo = new CategoryRepository();
+        $repo->add($category);
+        $this->persistenceManager->persistAll();
+        $this->persistenceManager->clearState();
+
+        $this->assertEquals(2, $category->getTranslations()->count());
+
+        $data = array(
+            '__identity' => $this->persistenceManager->getIdentifierByObject($category),
+            'icon' => 'new icon',
+            'color' => 'black',
+            'title' => array(
+                (string)$this->localeEn => 'Title EN updated',
+                (string)$this->localeDe => 'Title DE new',
+            )
+        );
+
+        $argument = new Argument('category', \CDSRC\Libraries\Tests\Functional\Translatable\Fixture\Model\Category::class);
+        $argument->setRequired(true);
+
+        $propertyMappingConfiguration = $argument->getPropertyMappingConfiguration();
+        $propertyMappingConfiguration->allowAllProperties('icon', 'color');
+        $propertyMappingConfiguration->setTypeConverterOption('TYPO3\\Flow\\Property\\TypeConverter\\PersistentObjectConverter',  \TYPO3\Flow\Property\TypeConverter\PersistentObjectConverter::CONFIGURATION_MODIFICATION_ALLOWED, TRUE);
+
+        $argument->setValue($data);
+
+        /** @var Category $updatedCategory */
+        $updatedCategory = $argument->getValue();
+
+        $this->assertEquals(2, $updatedCategory->getTranslations()->count());
+
+        $this->assertEquals('Title EN updated', $updatedCategory->setCurrentLocale($this->localeEn)->getTitle());
+        $this->assertNull($updatedCategory->setCurrentLocale($this->localeFr)->getCurrentLocale());
+        $this->assertEquals('Title DE new', $updatedCategory->setCurrentLocale($this->localeDe)->getTitle());
+    }
+}


### PR DESCRIPTION
A translated entity can be mapped with such array of arguments.

```
$category['icon'] = 'my icon';
$category['color'] = 'blue';
$category['title']['en_US'] = 'title EN-US';
$category['title']['fr_CH'] = 'title FR-CH';
```
